### PR TITLE
Use dotAll flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@
     ],
   };
 
-  var OPEN_TAG_REGEX = /^<([a-zA-Z0-9-]+)\s*(.*)?\/?>$/;
+  var OPEN_TAG_REGEX = /^<([a-zA-Z0-9-]+)\s*(.*)?\/?>$/s;
   var CLOSE_TAG_REGEX = /^<\/([a-zA-Z0-9-]+)\s*>$/;
 
   function escape(str) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-marked-sanitizer",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Simple sanitizer for marked",
   "main": "index.js",
   "scripts": {

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -135,4 +135,11 @@ describe("SimpleMarkedSanitizer", function() {
     const result = apply(input);
     assert.equal(result, output);
   });
+
+  it("with linefeed", () => {
+    const input  = '<img src="hoge" \n  alt="fuga"/>';
+    const output = '<p><img src="hoge" alt="fuga"/></p>';
+    const result = apply(input);
+    assert.equal(result, output);
+  });
 });


### PR DESCRIPTION
タグ内に改行がある場合にSanitizerが拾えていなかったバグの修正